### PR TITLE
Add CI workflow and fix vote tracker Newark callout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run tests
+        run: npm run test:run
+
+      - name: Build
+        env:
+          DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
+        run: npm run build

--- a/src/styles/articles/vote-tracker.css
+++ b/src/styles/articles/vote-tracker.css
@@ -502,6 +502,44 @@
   color: rgba(255, 255, 255, 0.5);
 }
 
+/* Newark Highlight Callout */
+.vote-newark-highlight {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 2rem;
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.06) 0%, rgba(239, 68, 68, 0.02) 100%);
+  border: 1px solid rgba(239, 68, 68, 0.15);
+  border-radius: 16px;
+  margin-top: 2rem;
+}
+
+.vote-newark-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.vote-newark-big {
+  font-size: clamp(4rem, 10vw, 7rem);
+  font-weight: 900;
+  line-height: 1;
+  background: linear-gradient(135deg, #ef4444 40%, rgba(239, 68, 68, 0.6) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.vote-newark-label {
+  font-size: var(--type-small);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  color: rgba(255, 255, 255, 0.5);
+  max-width: 280px;
+}
+
 /* Yes/No Section backgrounds */
 .vote-yes-section {
   background: linear-gradient(180deg, rgba(34, 197, 94, 0.02) 0%, transparent 100%);


### PR DESCRIPTION
## Summary
- **CI workflow**: Adds `.github/workflows/ci.yml` that runs `npm run test:run` and `npm run build` on every PR to main and push to main. Catches broken tests, build errors, and CSS import issues automatically.
- **Vote tracker fix**: The Newark "0 dissenting votes" callout (`vote-newark-highlight`, `vote-newark-stat`, `vote-newark-big`, `vote-newark-label`) had JSX markup but zero CSS definitions — rendered as unstyled inline text. Now displays as a prominent red-gradient callout card.

## Test plan
- [ ] CI workflow triggers on this PR (check Actions tab)
- [ ] Tests pass in CI
- [ ] Build passes in CI
- [ ] Vote tracker article renders Newark callout as styled card (large red "0" with label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)